### PR TITLE
Feature/plot modules

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,4 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
+  <component name="Black">
+    <option name="sdkName" value="Python 3.10" />
+  </component>
   <component name="ProjectRootManager" version="2" project-jdk-name="Python 3.10" project-jdk-type="Python SDK" />
 </project>

--- a/gui/plot_module_widget.py
+++ b/gui/plot_module_widget.py
@@ -1,0 +1,572 @@
+import os
+import sys
+import importlib.util
+import json
+from PyQt5.QtWidgets import (
+    QWidget, QVBoxLayout, QHBoxLayout, QCheckBox, QPushButton, QLabel,
+    QScrollArea, QMessageBox, QDockWidget, QDialog, QFormLayout, QDialogButtonBox,
+    QLineEdit, QComboBox, QColorDialog, QFileDialog
+)
+from PyQt5.QtCore import pyqtSignal, QSize, Qt
+from PyQt5.QtGui import QColor, QPainter, QPen
+from logger import get_logger
+
+def validate_bool(b): # Copied verbatim from matplotlib.rcsetup to avoid import
+    """Convert b to ``bool`` or raise."""
+    if isinstance(b, str):
+        b = b.lower()
+    if b in ('t', 'y', 'yes', 'on', 'true', '1', 1, True):
+        return True
+    elif b in ('f', 'n', 'no', 'off', 'false', '0', 0, False):
+        return False
+    else:
+        raise ValueError(f'Cannot convert {b!r} to bool')
+
+logger = get_logger(__name__)
+
+
+class PlotModule:
+    """Base class for plot modules"""
+    name = "Base Plot Module"
+    description = "Base Plot Module - You should never see this text"
+
+    def __init__(self, params = None):
+        self.params = params or {}
+
+    def plot(self, ax):
+        """Main plotting function - override in subclasses"""
+        pass
+
+    def disable(self, ax):
+        """ For the event that a plot is disabled """
+        pass
+
+def discover_plot_modules(modules_dir="plot_modules"):
+    """
+    Discover plot modules from the specified directory.
+    Returns a list of (module_name, module_class, description) tuples.
+    """
+    plot_modules = []
+    if not os.path.exists(modules_dir):
+        print(f"Plot modules directory not found: {modules_dir}")
+        return plot_modules
+
+    # Look for Python files in the modules directory
+    for filename in os.listdir(modules_dir):
+        if filename.endswith('.py') and not filename.startswith('__'):
+            module_name = filename[:-3]  # Remove .py extension
+            module_path = os.path.join(modules_dir, filename)
+
+            try:
+                # Load the module
+                spec = importlib.util.spec_from_file_location(module_name, module_path)
+                module = importlib.util.module_from_spec(spec)
+                spec.loader.exec_module(module)
+
+                # Look for a class that inherits from PlotModule
+                for attr_name in dir(module):
+                    if attr_name.startswith('__'): continue
+                    attr = getattr(module, attr_name)
+                    if (isinstance(attr, type) and issubclass(attr, PlotModule) and attr != PlotModule):
+                        # Check if it has the required attributes
+                        #if hasattr(attr, 'name') and hasattr(attr, 'description'): dont need to check, just instead throw an erro
+                        # PARAMETERS can be overridden within the class. Default to module parameters if not present.
+                        parameters = getattr(attr, 'PARAMETERS', getattr(module, 'PARAMETERS', []))
+
+                        plot_modules.append((f"{module_name}.{attr_name}", attr, attr.description, parameters))
+                        # break we can have multiple from one file?
+
+            except Exception as e:
+                print(f"Error loading plot module {filename}: {e}")
+
+    return plot_modules
+
+
+class PlotModuleWidget(QDockWidget):
+    """
+    A dockable widget for selecting and managing plot modules.
+    It discovers modules, displays them as a checklist with configuration options,
+    and emits a signal with configured module instances when selections are applied.
+    """
+    modulesChanged = pyqtSignal(list)
+
+    def __init__(self, parent=None):
+        super().__init__("Plot Modules", parent)
+        self.setAllowedAreas(Qt.LeftDockWidgetArea | Qt.RightDockWidgetArea)
+
+        self.discovered_modules = []
+        # NEW: Dictionary to store user-defined configurations for each module
+        self.module_configs = {}
+
+        self.main_widget = QWidget()
+        self.setWidget(self.main_widget)
+        self._init_ui()
+        self._load_modules()
+
+    def _init_ui(self):
+        layout = QVBoxLayout(self.main_widget)
+        desc_label = QLabel("Select modules to apply to the plot.")
+        desc_label.setWordWrap(True)
+        layout.addWidget(desc_label)
+
+        scroll_area = QScrollArea()
+        scroll_area.setWidgetResizable(True)
+        self.modules_container = QWidget()
+        self.modules_layout = QVBoxLayout(self.modules_container)
+        self.modules_layout.setSpacing(4)
+        self.modules_layout.setContentsMargins(5, 5, 5, 5)
+        scroll_area.setWidget(self.modules_container)
+        layout.addWidget(scroll_area)
+
+        btn_layout = QHBoxLayout()
+        self.select_all_btn = QPushButton("Select All")
+        self.deselect_all_btn = QPushButton("Deselect All")
+        self.apply_btn = QPushButton("Apply")
+        self.refresh_btn = QPushButton("Reload")
+        self.import_btn = QPushButton("Import")
+        self.export_btn = QPushButton("Export")
+
+        btn_layout.addWidget(self.select_all_btn)
+        btn_layout.addWidget(self.deselect_all_btn)
+        btn_layout.addStretch()
+        btn_layout.addWidget(self.import_btn)
+        btn_layout.addWidget(self.export_btn)
+        btn_layout.addWidget(self.refresh_btn)
+        btn_layout.addWidget(self.apply_btn)
+        layout.addLayout(btn_layout)
+
+        self.select_all_btn.clicked.connect(self.select_all_modules)
+        self.deselect_all_btn.clicked.connect(self.deselect_all_modules)
+        self.apply_btn.clicked.connect(self.apply_modules)
+        self.refresh_btn.clicked.connect(self.reload_modules)
+        self.import_btn.clicked.connect(self.import_module_config)
+        self.export_btn.clicked.connect(self.export_module_config)
+
+
+    def _clear_layout(self, layout):
+        while layout.count():
+            item = layout.takeAt(0)
+            widget = item.widget()
+            if widget is not None:
+                widget.deleteLater()
+
+    def _load_modules(self):
+        self._clear_layout(self.modules_layout)
+        self.discovered_modules = discover_plot_modules()
+
+        if not self.discovered_modules:
+            no_modules_label = QLabel("No plot modules found in 'plot_modules' directory.")
+            self.modules_layout.addWidget(no_modules_label)
+        else:
+            for module_name, module_class, description, parameters in self.discovered_modules:
+                # Each module is now a widget with its own horizontal layout
+                row_widget = QWidget()
+                row_layout = QHBoxLayout(row_widget)
+                row_layout.setContentsMargins(0, 0, 0, 0)
+
+                checkbox = QCheckBox(module_class.name)
+                checkbox.setToolTip(description)
+                checkbox.setProperty("module_name", module_name)
+                row_layout.addWidget(checkbox)
+                row_layout.addStretch()
+
+                # NEW: If the module has parameters, add a "Configure" button
+                if parameters:
+                    config_btn = QPushButton("Configure...")
+                    config_btn.setProperty("module_name", module_name)
+                    config_btn.clicked.connect(self._open_config_dialog)
+                    row_layout.addWidget(config_btn)
+
+                self.modules_layout.addWidget(row_widget)
+
+        self.modules_layout.addStretch(1)
+
+
+    def _checked_modules(self):
+        """Loads which modules are currently checked, for use on reloading modules"""
+        checked_modules = [] # Can be set but with overhead
+        for i in range(self.modules_layout.count()):
+            row_widget = self.modules_layout.itemAt(i).widget()
+            if not isinstance(row_widget, QWidget): continue
+
+            checkbox = row_widget.findChild(QCheckBox)
+            if checkbox and checkbox.isChecked():
+                if checkbox.property("module_name"):
+                    checked_modules.append(checkbox.property("module_name"))
+
+        return checked_modules
+
+    def _check_modules(self, modules):
+        """Checks a list of specified modules"""
+        for i in range(self.modules_layout.count()):
+            row_widget = self.modules_layout.itemAt(i).widget()
+            if not isinstance(row_widget, QWidget): continue
+
+            checkbox = row_widget.findChild(QCheckBox)
+            if checkbox and checkbox.property("module_name") in modules:
+                checkbox.setChecked(True)
+
+
+    def _open_config_dialog(self):
+        """Opens the configuration dialog for a specific module."""
+        sender_btn = self.sender()
+        module_name = sender_btn.property("module_name")
+
+        # Find the module's definition
+        module_def = next((m for m in self.discovered_modules if m[0] == module_name), None)
+
+        if not module_def:
+            return
+
+        _, module_class, _, parameters = module_def
+
+        # Get the currently stored configuration for this module
+        current_config = self.module_configs.get(module_name, {})
+
+        dialog = ModuleConfigDialog(module_class.name, parameters, current_config, self)
+        if dialog.exec_() == QDialog.Accepted:
+            # If user clicks OK, save the new configuration
+            self.module_configs[module_name] = dialog.get_params()
+
+    def select_all_modules(self):
+        for i in range(self.modules_layout.count()):
+            widget = self.modules_layout.itemAt(i).widget()
+            if widget and isinstance(widget, QWidget):
+                checkbox = widget.findChild(QCheckBox)
+                if checkbox:
+                    checkbox.setChecked(True)
+
+    def deselect_all_modules(self):
+        for i in range(self.modules_layout.count()):
+            widget = self.modules_layout.itemAt(i).widget()
+            if widget and isinstance(widget, QWidget):
+                checkbox = widget.findChild(QCheckBox)
+                if checkbox:
+                    checkbox.setChecked(False)
+
+    def _reload_modules(self):
+        """
+        Just reloads the actual modules and updates the layout
+        """
+        checked_modules = self._checked_modules()
+        self._clear_layout(self.modules_layout)
+        self._load_modules()
+        self._check_modules(checked_modules)
+
+    def reload_modules(self):
+        """Reloads all modules on demand (say a user changed one, for example)"""
+        self._reload_modules()
+        self.apply_modules()
+
+    def apply_modules(self):
+        """Instantiates selected modules with their configs and emits the signal."""
+        enabled_instances = self.export_modules()
+        QMessageBox.information(self, "Modules Applied", f"Applied {len(enabled_instances)} plot module(s).")
+        self.modulesChanged.emit(enabled_instances) # Do i keep this here?
+
+    def export_modules(self):
+        """
+        Exports current list of enabled instances by request
+        """
+        enabled_instances = []
+
+        # Find which modules are checked in the UI
+        for i in range(self.modules_layout.count()):
+            row_widget = self.modules_layout.itemAt(i).widget()
+            if not isinstance(row_widget, QWidget): continue
+
+            checkbox = row_widget.findChild(QCheckBox)
+            if checkbox and checkbox.isChecked():
+                module_name = checkbox.property("module_name")
+                module_def = next((m for m in self.discovered_modules if m[0] == module_name), None)
+
+                if module_def:
+                    _, module_class, _, _ = module_def
+                    # Get config for this module, or an empty dict if none
+                    config = self.module_configs.get(module_name, {})
+                    try:
+                        # Pass the config to the module's constructor
+                        instance = module_class(params=config)
+                        enabled_instances.append(instance)
+                    except Exception as e:
+                        logger.error(f"Error creating instance of {module_class.name}: {e}")
+
+        return enabled_instances
+
+
+    def export_module_config(self):
+        """Saves the current module selections and configurations to a JSON file."""
+        logger.debug("Exporting module configuration.")
+
+        config_data = {
+            'active_modules': self._checked_modules(),
+            'configurations': self.module_configs
+        }
+
+        file_path, _ = QFileDialog.getSaveFileName(self, "Export Module Configuration", "", "JSON Files (*.json)")
+        if not file_path:
+            return
+
+        try:
+            with open(file_path, 'w') as f:
+                json.dump(config_data, f, indent=2)
+            QMessageBox.information(self, "Export Successful", f"Module configuration saved to:\n{file_path}")
+        except Exception as e:
+            QMessageBox.warning(self, "Export Error", f"Failed to save configuration: {e}")
+            logger.error(f"Failed to export module config: {e}")
+
+
+    def import_module_config(self):
+        """Loads module selections and configurations from a JSON file."""
+        logger.debug("Importing module configuration.")
+
+        file_path, _ = QFileDialog.getOpenFileName(self, "Import Module Configuration", "", "JSON Files (*.json)")
+        if not file_path:
+            return
+
+        try:
+            with open(file_path, 'r') as f:
+                config_data = json.load(f)
+        except Exception as e:
+            QMessageBox.warning(self, "Import Error", f"Failed to read or parse file: {e}")
+            logger.error(f"Failed to import module config: {e}")
+            return
+
+        # Validate the imported data
+        if 'active_modules' not in config_data or 'configurations' not in config_data:
+            QMessageBox.warning(self, "Import Error", "Invalid configuration file format.")
+            return
+
+        # Update the internal state
+        self.module_configs = config_data.get('configurations', {})
+        active_modules_to_check = config_data.get('active_modules', [])
+
+        # Update the UI
+        self.deselect_all_modules()
+        self._check_modules(active_modules_to_check)
+
+        # Apply the changes
+        self.apply_modules()
+        logger.info("Module configuration loaded and applied.")
+
+
+class ColorButton(QPushButton):
+    def __init__(self, color=None, parent=None):
+        super().__init__(parent)
+        self.setFixedSize(QSize(40, 24))
+        self._color = color
+        self.setToolTip("Choose Color")
+        self.update_style()
+        self.clicked.connect(self.choose_color)
+
+    def set_color(self, color):
+        self._color = color
+        self.update()
+        self.update_style()
+
+    def get_color(self):
+        return self._color
+
+    def paintEvent(self, event):
+        super().paintEvent(event)
+        painter = QPainter(self)
+        rect = self.rect().adjusted(4, 4, -4, -4)
+        if self._color:
+            painter.setBrush(self._color)
+            painter.setPen(QPen(QColor('black'), 1))
+            painter.drawRect(rect)
+        else:
+            painter.setBrush(QColor('white'))
+            painter.setPen(QPen(QColor('black'), 1))
+            painter.drawRect(rect)
+            # Draw red diagonal line
+            pen = QPen(QColor('red'), 2)
+            painter.setPen(pen)
+            painter.drawLine(rect.topLeft(), rect.bottomRight())
+
+    def mousePressEvent(self, event):
+        super().mousePressEvent(event)
+        if event.button() == Qt.RightButton:
+            self.remove_color()
+
+    def update_style(self):
+        if self._color:
+            self.setStyleSheet(f"background-color: {self._color.name()}; border: 1px solid #888;")
+        else:
+            self.setStyleSheet("background-color: white; border: 1px solid #888;")
+
+    def choose_color(self):
+        color = QColorDialog.getColor(self._color or QColor(0, 0, 0), None, "Choose Color")
+        if color.isValid():
+            self.set_color(color)
+
+    def remove_color(self):
+        self.set_color(None)
+
+
+class ModuleConfigDialog(QDialog):
+    """
+    A generic dialog to configure module parameters.
+    It dynamically builds a form based on a PARAMETERS definition list.
+    """
+
+    def __init__(self, module_name, parameters, current_values=None, parent=None):
+        super().__init__(parent)
+        self.setWindowTitle(f"Configure: {module_name}")
+        self.setMinimumWidth(350)
+
+        self.parameters = parameters
+        self.current_values = current_values or {}
+        self.param_widgets = {}
+
+        layout = QVBoxLayout(self)
+        form_layout = QFormLayout()
+
+        # Build the form from the parameter definitions
+        for name, label, typ, _, default in parameters:
+            widget = self._make_widget_for_type(typ, default)
+
+            # Set the widget's current value from saved config or default
+            current_val = self.current_values.get(name, default)
+            self._set_widget_value(widget, current_val)
+
+            form_layout.addRow(f"{label}:", widget)
+            self.param_widgets[name] = widget
+
+        layout.addLayout(form_layout)
+        # New buttons, adding a reset to default option:
+        button_layout = QHBoxLayout()
+        reset_btn = QPushButton("Reset to Defaults")
+        reset_btn.clicked.connect(self.reset_to_defaults)
+        button_layout.addWidget(reset_btn)
+        button_layout.addStretch(1)
+        # OK and Cancel buttons
+        button_box = QDialogButtonBox(QDialogButtonBox.Ok | QDialogButtonBox.Cancel)
+        button_box.accepted.connect(self.accept)
+        button_box.rejected.connect(self.reject)
+        button_layout.addWidget(button_box)
+        layout.addLayout(button_layout)
+        #layout.addWidget(button_box)
+
+    def reset_to_defaults(self):
+        """
+        Resets all parameter widgets in the dialog to their default values
+        as defined in the module's PARAMETERS list.
+        """
+        for name, label, typ, required, default_value in self.parameters:
+            if name in self.param_widgets:
+                widget = self.param_widgets[name]
+                # Special handling for color type, as its default_value might be a string like 'gray'
+                # and needs to be processed by _process_mpl_color_default before setting on ColorButton.
+                if typ == 'color':
+                    processed_default = self._process_mpl_color_default(default_value)
+                    if processed_default:
+                        widget.set_color(QColor(processed_default))
+                    else:
+                        widget.set_color(None)  # Clear the color if default is None/empty
+                else:
+                    self._set_widget_value(widget, default_value)
+        #QMessageBox.information(self, "Reset", "Parameters reset to default values.")
+
+    def _process_mpl_color_default(self, value):
+        """Small helper to process mpl rcparam color values"""
+        if not value:
+            return None
+        if type(value) == str:
+            if value in ['None', 'auto', 'inherit']:
+                return None
+            # Test if float
+            try:
+                value = float(value)
+                value *= (255 if value <= 1 else 1)
+                value = int(value)
+                return QColor(value, value, value, 1).name()
+            except ValueError:
+                pass
+        if type(value) == float:
+            value *= (255 if value <= 1 else 1)
+            value = int(value)
+            return QColor(value, value, value, 1).name()
+        if type(value) == int:
+            return QColor(value, value, value, 1).name()
+        return value
+
+    def _make_widget_for_type(self, typ, default_value):
+        """Creates the appropriate QWidget for a given parameter type."""
+        if isinstance(typ, (list, tuple)):
+            widget = QComboBox()
+            widget.addItems([str(v) for v in typ])
+        elif typ == bool or typ == 'checkbox':
+            widget = QCheckBox()
+        elif typ == 'color':
+            widget = ColorButton()
+            if default_value:
+                default_value = self._process_mpl_color_default(default_value)
+                if default_value: # this case we'd want it to be clear and handled by mpl
+                    widget.set_color(QColor(default_value))
+        else:  # Handles str, int, float, etc.
+            widget = QLineEdit()
+            if default_value is not None:
+                widget.setPlaceholderText(str(default_value))
+        return widget
+
+    def _set_widget_value(self, widget, value):
+        """Sets the value of a widget, handling different widget types."""
+        if value is None:
+            return
+
+        if isinstance(widget, QComboBox):
+            index = widget.findText(str(value))
+            if index > -1:
+                widget.setCurrentIndex(index)
+        elif isinstance(widget, QCheckBox):
+            widget.setChecked(validate_bool(value))
+        elif isinstance(widget, ColorButton):
+            try:
+                value = self._process_mpl_color_default(value)
+                if value:
+                    widget.set_color(QColor(value))
+            except Exception as e:
+                logger.info(f"Could not set color widget to {value}: {e}")
+        elif isinstance(widget, QLineEdit):
+            widget.setText(str(value))
+
+    def get_params(self):
+        """Reads the configured values from the widgets and returns them as a dict."""
+        params = {}
+        for name, widget in self.param_widgets.items():
+            # Find the original parameter definition to get the type
+            param_def = next((p for p in self.parameters if p[0] == name), None)
+            typ = param_def[2] if param_def else str
+            value = None
+
+            if isinstance(widget, QComboBox):
+                value = widget.currentText()
+            elif isinstance(widget, QCheckBox):
+                value = widget.isChecked()
+                params[name] = value
+                continue
+            elif isinstance(widget, ColorButton):
+                color = widget.get_color()
+                value = color.name() if color else None
+            elif isinstance(widget, QLineEdit):
+                value = widget.text()
+                # Try to cast to the correct type (e.g., float, int)
+                if isinstance(typ, type) and value:
+                    try:
+                        value = typ(value)
+                    except (ValueError, TypeError):
+                        # On failure, use the default value from the definition
+                        value = param_def[4] if param_def else None
+                elif not value:
+                    value = param_def[4] if param_def else None
+
+            if (param_def and param_def[3]) and not value:
+                QMessageBox.warning(self, f"Missing Parameter: {name}", f"You must specify a value for this parameter: '{param_def[1]}'.")
+                return {} # We wont specify any parameters
+
+
+            if value: # We don't want to give None values!
+                params[name] = value
+
+        return params

--- a/gui/plot_module_widget.py
+++ b/gui/plot_module_widget.py
@@ -30,22 +30,27 @@ class PlotModule:
     name = "Base Plot Module"
     description = "Base Plot Module - You should never see this text"
 
+    reset_plot = False # This flag should be set to true should any modifications require a reset (init and disable)
+
     def __init__(self, params = None):
         self.params = params or {}
 
     def initialize(self):
         """
         Possible functions to be called before mpl canvas is created, this is typically to affect global settings (i.e. styles)
-        If a script requires a full plot reset, it must return True in the initialization code
+        If the initialization function requires a full plot reset, it must return True
         """
-        return False
+        pass
 
     def plot(self, ax):
         """Main plotting function - override in subclasses"""
         pass
 
     def disable(self, ax):
-        """ For the event that a plot is disabled """
+        """
+        For the event that a plot is disabled.
+        If the disable function requires a full plot reset, it must return True
+        """
         pass
 
 def discover_plot_modules(modules_dir="plot_modules"):
@@ -102,7 +107,7 @@ class PlotModuleWidget(QDockWidget):
         self.setAllowedAreas(Qt.LeftDockWidgetArea | Qt.RightDockWidgetArea)
 
         self.discovered_modules = []
-        # NEW: Dictionary to store user-defined configurations for each module
+        # Dictionary to store user-defined configurations for each module
         self.module_configs = {}
 
         self.main_widget = QWidget()
@@ -177,7 +182,7 @@ class PlotModuleWidget(QDockWidget):
                 row_layout.addWidget(checkbox)
                 row_layout.addStretch()
 
-                # NEW: If the module has parameters, add a "Configure" button
+                # If the module has parameters, add a "Configure" button
                 if parameters:
                     config_btn = QPushButton("Configure...")
                     config_btn.setProperty("module_name", module_name)
@@ -303,7 +308,7 @@ class PlotModuleWidget(QDockWidget):
         return enabled_instances
 
 
-    def export_module_config(self):
+    def export_module_config(self, file_path = None):
         """Saves the current module selections and configurations to a JSON file."""
         logger.debug("Exporting module configuration.")
 
@@ -311,10 +316,10 @@ class PlotModuleWidget(QDockWidget):
             'active_modules': self._checked_modules(),
             'configurations': self.module_configs
         }
-
-        file_path, _ = QFileDialog.getSaveFileName(self, "Export Module Configuration", "plot_modules.json", "JSON Files (*.json)")
-        if not file_path:
-            return
+        if not file_path: # If not supplied, we simply ask
+            file_path, _ = QFileDialog.getSaveFileName(self, "Export Module Configuration", "plot_modules.json", "JSON Files (*.json)")
+            if not file_path: # If still not given, we return
+                return
 
         try:
             with open(file_path, 'w') as f:

--- a/gui/processing_dialog.py
+++ b/gui/processing_dialog.py
@@ -505,10 +505,11 @@ class ProcessingDialog(QDialog):
                     if not group_values:
                         raise ValueError(f"At least one group required for '{label}'.")
 
-    def import_params(self):
-        file_path, _ = QFileDialog.getOpenFileName(self, "Import Parameters", "", "JSON Files (*.json)")
-        if not file_path:
-            return
+    def import_params(self, file_path = None):
+        if not file_path: # If not supplied, we simply ask
+            file_path, _ = QFileDialog.getOpenFileName(self, "Import Parameters", "", "JSON Files (*.json)")
+            if not file_path:
+                return
         try:
             with open(file_path, 'r') as f:
                 params = json.load(f)
@@ -588,7 +589,7 @@ class ProcessingDialog(QDialog):
             QMessageBox.warning(self, "Import Error", str(e))
             logger.warning(f"Import Error: {e}")
 
-    def export_params(self):
+    def export_params(self, file_path = None):
         try:
             params = self.get_params(includeBaseParams=False) # excluse base parameters
             # Add module name
@@ -598,9 +599,10 @@ class ProcessingDialog(QDialog):
             QMessageBox.warning(self, "Export Error", str(e))
             logger.warning(f"Export Error: {e}")
             return
-        file_path, _ = QFileDialog.getSaveFileName(self, "Export Parameters", "params.json", "JSON Files (*.json)")
-        if not file_path:
-            return
+        if not file_path: # If not supplied, we simply ask
+            file_path, _ = QFileDialog.getSaveFileName(self, "Export Parameters", "params.json", "JSON Files (*.json)")
+            if not file_path:
+                return
         try:
             with open(file_path, 'w') as f:
                 json.dump(params, f, indent=2)

--- a/localvars.py
+++ b/localvars.py
@@ -16,4 +16,7 @@ DEFAULT_PLOT_SAVE = os.path.join(PLOTS_DIR, 'plot.pdf')
 # Reading/writing data file formats
 DATA_DELIMITER = '  '
 
+# Behaviour flags
+REREAD_DATAFILE_ON_EDIT = False
+
 # Any other constants can be added here 

--- a/plot_modules/__init__.py
+++ b/plot_modules/__init__.py
@@ -1,0 +1,1 @@
+# Plot modules package 

--- a/plot_modules/colorbar_module.py
+++ b/plot_modules/colorbar_module.py
@@ -1,0 +1,27 @@
+from gui.plot_module_widget import PlotModule
+
+
+class ColorbarModule(PlotModule):
+    """Adds a colorbar to plots"""
+    name = "Colobar Module"
+    description = "Adds a colorbar to plots with customizable position and label"
+
+    def __init__(self):
+        super().__init__()
+        self.colorbar_label = "Value"
+        self.colorbar_position = 'right'
+        self.colorbar_fraction = 0.046
+        self.colorbar_pad = 0.04
+    
+    def plot(self, ax):
+        """Add colorbar to the plot"""
+        # Check if there are any mappable objects (like scatter plots with color)
+        mappable = None
+        for collection in ax.collections:
+            if hasattr(collection, 'get_array') and collection.get_array() is not None:
+                mappable = collection
+                break
+        
+        if mappable is not None:
+            cbar = plt.colorbar(mappable, ax=ax, fraction=self.colorbar_fraction, pad=self.colorbar_pad)
+            cbar.set_label(self.colorbar_label)

--- a/plot_modules/colorbar_module.py
+++ b/plot_modules/colorbar_module.py
@@ -1,5 +1,5 @@
 from gui.plot_module_widget import PlotModule
-
+import matplotlib.pyplot as plt
 
 class ColorbarModule(PlotModule):
     """Adds a colorbar to plots"""

--- a/plot_modules/custom_script_module.py
+++ b/plot_modules/custom_script_module.py
@@ -1,0 +1,66 @@
+from gui.plot_module_widget import PlotModule
+import matplotlib.pyplot as plt
+import numpy as np
+from logger import get_logger
+
+logger = get_logger(__name__)
+
+# Define the parameters for this module. The 'textarea' type will be multiline
+PARAMETERS = [
+    ('script_text', 'Custom Script', 'textarea', False,
+     '# Example:\n# ax.set_title("My Custom Title")\n# ax.axvline(x=0, color=\'r\', linestyle=\'--\')'),
+]
+
+
+class CustomScriptModule(PlotModule):
+    """
+    Executes a custom Python script with access to the plot's figure and axes.
+    Warning: Changes made by this script are not automatically undone when disabled.
+    A full plot reset or re-applying other modules may be necessary to revert changes.
+    """
+    name = "Custom Script"
+    description = "Run custom Python code with access to 'fig', 'ax', 'plt', and 'np'."
+    PARAMETERS = PARAMETERS
+
+    def __init__(self, params=None):
+        super().__init__(params)
+        self.script = self.params.get('script_text', '')
+
+    def initialize(self):
+        return True # Force a hard plot reset
+
+    def plot(self, ax):
+        """
+        Executes the user-provided script in a controlled environment.
+        """
+        if not self.script or not self.script.strip():
+            logger.debug("Custom script is empty or only contains comments. Skipping execution.")
+            return
+
+        fig = ax.figure
+
+        # Create a controlled execution environment.
+        # The script will have access to these variables.
+        execution_scope = {
+            'np': np,
+            'plt': plt,
+            'ax': ax,
+            'fig': fig,
+        }
+
+        logger.info(f"Executing custom script:\n---\n{self.script}\n---")
+        try:
+            # Execute the script. Globals are empty for security.
+            exec(self.script, {}, execution_scope)
+        except Exception as e:
+            logger.error(f"Error executing custom script: {e}", exc_info=True)
+            # We could raise this to show a QMessageBox, but logging is less intrusive.
+
+    def disable(self, ax):
+        """
+        This method cannot reliably undo arbitrary code execution.
+        It serves as a placeholder and logs a warning.
+        """
+        logger.warning(f"Disabling '{self.name}' does not undo the executed script. "
+                       "A plot reset or re-applying other modules may be necessary to override changes.")
+        # No actions are taken as we cannot know what the script did.

--- a/plot_modules/figure_module.py
+++ b/plot_modules/figure_module.py
@@ -1,0 +1,145 @@
+# C:/Users/zberks/OneDrive - McGill University/G2/CorbinoAnalysis/plot_modules/figure_module.py
+
+from gui.plot_module_widget import PlotModule
+import matplotlib.pyplot as plt
+from logger import get_logger
+
+logger = get_logger(__name__)
+
+# Define the parameters that the user can configure for the figure and axes
+PARAMETERS = [
+    # (name, label, type, required, default_value)
+
+    # --- Figure-level parameters ---
+    ('figure_facecolor', 'Figure Face Color', 'color', False, plt.rcParams['figure.facecolor']),
+    ('figure_edgecolor', 'Figure Edge Color', 'color', False, plt.rcParams['figure.edgecolor']),
+
+    # --- Axes-level parameters ---
+    ('axes_facecolor', 'Axes Face Color', 'color', False, plt.rcParams['axes.facecolor']),
+    ('axes_edgecolor', 'Axes Spine Color', 'color', False, plt.rcParams['axes.edgecolor']),
+    ('axes_linewidth', 'Axes Spine Linewidth', float, False, plt.rcParams['axes.linewidth']),
+    ('axes_labelcolor', 'Axes Label Color', 'color', False, plt.rcParams['axes.labelcolor']),
+    ('axes_titlecolor', 'Title Color', 'color', False, plt.rcParams['axes.titlecolor']),
+
+    # --- Global X-Tick Parameters ---
+    ('xtick_direction', 'X-Tick Direction', ('in', 'out', 'inout'), False, plt.rcParams['xtick.direction']),
+    ('xtick_color', 'X-Tick Color', 'color', False, plt.rcParams['xtick.color']),
+    ('xtick_labelsize', 'X-Tick Label Size', ('xx-small', 'x-small', 'small', 'medium', 'large', 'x-large', 'xx-large'),
+     False, plt.rcParams['xtick.labelsize']),
+    ('xtick_labelcolor', 'X-Tick Label Color', 'color', False, plt.rcParams['xtick.labelcolor']),
+    ('xtick_top', 'Show Top X-Ticks', bool, False, plt.rcParams['xtick.top']),
+    ('xtick_bottom', 'Show Bottom X-Ticks', bool, False, plt.rcParams['xtick.bottom']),
+    ('xtick_labeltop', 'Show Top X-Labels', bool, False, plt.rcParams['xtick.labeltop']),
+    ('xtick_labelbottom', 'Show Bottom X-Labels', bool, False, plt.rcParams['xtick.labelbottom']),
+
+    # --- Global Y-Tick Parameters ---
+    ('ytick_direction', 'Y-Tick Direction', ('in', 'out', 'inout'), False, plt.rcParams['ytick.direction']),
+    ('ytick_color', 'Y-Tick Color', 'color', False, plt.rcParams['ytick.color']),
+    ('ytick_labelsize', 'Y-Tick Label Size', ('xx-small', 'x-small', 'small', 'medium', 'large', 'x-large', 'xx-large'),
+     False, plt.rcParams['ytick.labelsize']),
+    ('ytick_labelcolor', 'Y-Tick Label Color', 'color', False, plt.rcParams['ytick.labelcolor']),
+    ('ytick_left', 'Show Left Y-Ticks', bool, False, plt.rcParams['ytick.left']),
+    ('ytick_right', 'Show Right Y-Ticks', bool, False, plt.rcParams['ytick.right']),
+    ('ytick_labelleft', 'Show Left Y-Labels', bool, False, plt.rcParams['ytick.labelleft']),
+    ('ytick_labelright', 'Show Right Y-Labels', bool, False, plt.rcParams['ytick.labelright']),
+]
+
+
+class FigureModule(PlotModule):
+    """
+    Controls global visual parameters of the figure and axes,
+    such as background colors, spine properties, and global tick styles.
+    """
+    name = "Figure/Axes Style"
+    description = "Controls global figure/axes colors, line properties, and general tick appearance."
+    PARAMETERS = PARAMETERS
+
+    def __init__(self, params=None):
+        super().__init__(params)
+        # Capture the rcParams defaults *at the time this instance is created*
+        self._initial_rc_params = {}
+        for name, _, _, _, _ in self.PARAMETERS:
+            # Most parameter names map directly to rcParams keys by replacing '_' with '.'
+            rc_key = name.replace('_', '.')
+            try:
+                self._initial_rc_params[name] = plt.rcParams[rc_key]
+            except KeyError:
+                logger.warning(f"Could not find rcParam for '{name}' using key '{rc_key}'.")
+                self._initial_rc_params[name] = None
+
+    def _get_revert_color(self, param_name):
+        """
+        Determines the correct color value to revert to.
+        If the initial rcParam was 'None', 'inherit', or 'auto', return None.
+        Otherwise, return the captured color value.
+        """
+        initial_value = self._initial_rc_params.get(param_name)
+        if isinstance(initial_value, str) and initial_value.lower() in ['none', 'inherit', 'auto']:
+            return None
+        return initial_value
+
+    def plot(self, ax):
+        """Apply figure and axes styling."""
+        fig = ax.figure
+
+        # --- Apply Figure-level Parameters ---
+        fig.set_facecolor(self.params.get('figure_facecolor'))
+        fig.set_edgecolor(self.params.get('figure_edgecolor'))
+
+        # --- Apply Axes-level Parameters ---
+        ax.set_facecolor(self.params.get('axes_facecolor'))
+
+        # Apply spine color and width
+        for spine in ax.spines.values():
+            spine.set_edgecolor(self.params.get('axes_edgecolor'))
+            spine.set_linewidth(self.params.get('axes_linewidth'))
+
+        # Apply label and title colors
+        ax.xaxis.label.set_color(self.params.get('axes_labelcolor'))
+        ax.yaxis.label.set_color(self.params.get('axes_labelcolor'))
+        ax.title.set_color(self.params.get('axes_titlecolor'))
+
+        # --- Apply Global Tick Parameters ---
+        x_tick_params = {k.replace('xtick_', ''): v for k, v in self.params.items() if k.startswith('xtick_')}
+        y_tick_params = {k.replace('ytick_', ''): v for k, v in self.params.items() if k.startswith('ytick_')}
+
+        if x_tick_params:
+            ax.tick_params(axis='x', which='both', **x_tick_params)
+        if y_tick_params:
+            ax.tick_params(axis='y', which='both', **y_tick_params)
+
+    def disable(self, ax):
+        """Revert figure and axes styling to the rcParams defaults captured at module instantiation."""
+        fig = ax.figure
+
+        # Revert figure properties using the smart color reversion
+        fig.set_facecolor(self._get_revert_color('figure_facecolor'))
+        fig.set_edgecolor(self._get_revert_color('figure_edgecolor'))
+
+        # Revert axes properties
+        ax.set_facecolor(self._get_revert_color('axes_facecolor'))
+
+        # Revert spines
+        for spine in ax.spines.values():
+            spine.set_edgecolor(self._get_revert_color('axes_edgecolor'))
+            spine.set_linewidth(self._initial_rc_params.get('axes_linewidth'))
+
+        # Revert labels and title
+        ax.xaxis.label.set_color(self._get_revert_color('axes_labelcolor'))
+        ax.yaxis.label.set_color(self._get_revert_color('axes_labelcolor'))
+        ax.title.set_color(self._get_revert_color('axes_titlecolor'))
+
+        # Revert global tick parameters
+        default_x_params = {
+            k.replace('xtick_', ''): self._get_revert_color(k) if 'color' in k else self._initial_rc_params.get(k)
+            for k in self._initial_rc_params if k.startswith('xtick_')
+        }
+        default_y_params = {
+            k.replace('ytick_', ''): self._get_revert_color(k) if 'color' in k else self._initial_rc_params.get(k)
+            for k in self._initial_rc_params if k.startswith('ytick_')
+        }
+
+        if default_x_params:
+            ax.tick_params(axis='x', which='both', **default_x_params)
+        if default_y_params:
+            ax.tick_params(axis='y', which='both', **default_y_params)

--- a/plot_modules/figure_module.py
+++ b/plot_modules/figure_module.py
@@ -1,5 +1,3 @@
-# C:/Users/zberks/OneDrive - McGill University/G2/CorbinoAnalysis/plot_modules/figure_module.py
-
 from gui.plot_module_widget import PlotModule
 import matplotlib.pyplot as plt
 from logger import get_logger

--- a/plot_modules/grid_module.py
+++ b/plot_modules/grid_module.py
@@ -1,0 +1,40 @@
+from gui.plot_module_widget import PlotModule
+import matplotlib.pyplot as plt
+# Define the parameters that the user can configure
+
+
+PARAMETERS = [
+    # (name, label, type, required, default_value)
+    ('grid_alpha', 'Alpha', float, False, plt.rcParams['grid.alpha']),
+    ('grid_style', 'Style', ('-', '--', '-.', ':'), False, plt.rcParams['grid.linestyle']),
+    ('grid_color', 'Color', 'color', True, plt.rcParams['grid.color']),
+    ('grid_lw', 'Linewidth', float, False, plt.rcParams['grid.linewidth']),
+    ('grid_axes', 'Axes', ('both', 'x', 'y'), False, plt.rcParams['axes.grid.axis']),
+    ('grid_which', 'Which', ('both', 'major', 'minor'), False, plt.rcParams['axes.grid.which'])
+]
+
+# Note, Future rcparam widget will not change these. It would be a good idea to make setting rcparams reload all plot modules
+DEFAULTS = {name:default for name,_,_,_,default in PARAMETERS}
+
+class GridModule(PlotModule):
+    """Adds a grid to plots"""
+    name = "Grid Module"
+    description = "Adds a customizable grid to plots with configurable style and alpha"
+
+    def __init__(self, params=None):
+        super().__init__(params)
+        # Use the passed-in params, falling back to defaults
+        self.grid_alpha = self.params.get('grid_alpha', 0.8)
+        self.grid_style = self.params.get('grid_style', '-')
+        self.grid_color = self.params.get('grid_color', 'gray')
+        self.grid_axes = self.params.get('grid_axes', 'both')
+        self.grid_which = self.params.get('grid_which', 'major')
+        self.grid_lw = self.params.get('grid_lw', 1.0)
+
+    def plot(self, ax):
+        """Add grid to the plot using configured parameters"""
+        ax.grid(True, alpha=self.grid_alpha, linestyle=self.grid_style, color=self.grid_color, which=self.grid_which, axis=self.grid_axes, linewidth=self.grid_lw)
+
+    def disable(self, ax):
+        """Reset the grid parameters which get saved when calling the grid function in plot()"""
+        ax.grid(alpha = DEFAULTS['grid_alpha'], linestyle=DEFAULTS['grid_style'], color=DEFAULTS['grid_color'], which=DEFAULTS['grid_which'], axis=DEFAULTS['grid_axes'], linewidth=DEFAULTS['grid_lw'])

--- a/plot_modules/labeloffset_module.py
+++ b/plot_modules/labeloffset_module.py
@@ -1,0 +1,69 @@
+from gui.plot_module_widget import PlotModule
+import re
+
+# TODO: add paremeters?
+class LabelOffset(PlotModule):
+    name = 'Label Offset'
+    description = 'Automatically add the order of magnitude to the axis labels'
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        self.ax = None
+        self.cids = [] # Callback IDs to cancel on redraw
+
+    def __offset_to_latex(self, offset):
+        if offset == '':
+            return ''
+        float_str = offset if 'e' in offset else "{0:.2g}".format(float(offset))
+        if "e" in float_str:
+            try:
+                base, exponent = float_str.replace(u"\u2212", "-").split("e")
+                if int(base) != 1: # just incase its 0.99999 or something
+                    return r"[x${0} \times 10^{{{1}}}$]".format(base, int(float(exponent)))
+                else:
+                    return r"[$\times 10^{{{0}}}$]".format(int(float(exponent)))
+            except:
+                return float_str
+        else:
+            return float_str
+
+    def plot(self, ax):
+
+        if self.ax is not ax:
+            # Disconnect previous callbacks
+            if self.ax is not None:
+                for cid in self.cids:
+                    self.ax.callbacks.disconnect(cid)
+            self.ax = ax
+            self.cids = [
+                self.ax.callbacks.connect('xlim_changed', self.update),
+                self.ax.callbacks.connect('ylim_changed', self.update)
+            ]
+
+        self.update(None)
+
+
+    def update(self, artist = None): # What to do with artist ??
+        if self.ax is None:
+            return
+
+        offset_pattern = re.compile(r"\s\[.*\\times\s10\^\{.*\}\$\]$")
+        for axis in ['xaxis', 'yaxis']:
+            axis = getattr(self.ax, axis)
+            label = axis.get_label().get_text()
+            label = offset_pattern.sub('', label) # Remove any previous offset
+
+            fmt = axis.get_major_formatter()
+            offset_str = self.__offset_to_latex(fmt.get_offset())
+
+            if label and offset_str:
+                axis.offsetText.set_visible(False)
+                axis.set_label_text(f"{label} {offset_str}")
+
+    def disable(self, ax):
+        if self.ax:
+            for cid in self.cids:
+                self.ax.callbacks.disconnect(cid)
+            self.cids = []
+            self.ax = None

--- a/plot_modules/legend_module.py
+++ b/plot_modules/legend_module.py
@@ -1,0 +1,59 @@
+from gui.plot_module_widget import PlotModule
+import matplotlib.pyplot as plt
+
+#for k,v in plt.rcParams.items():
+#    if 'legend' in k:
+#        print(k,v)
+# Define the parameters that the user can configure
+PARAMETERS = [
+    # (name, label, type, required, default_value)
+    ('legend_loc', 'Location', ('best', 'upper right', 'upper left', 'lower left', 'lower right',
+                                  'right', 'center left', 'center right', 'lower center', 'upper center', 'center'), False, plt.rcParams['legend.loc']),
+    ('legend_fontsize', 'Font Size', ( 'xx-small', 'x-small', 'small', 'medium', 'large', 'x-large', 'xx-large'), False, plt.rcParams['legend.fontsize']),
+    ('legend_frameon', 'Show Frame', bool, False, plt.rcParams['legend.frameon']),
+    ('legend_framealpha', 'Frame Alpha', float, False, plt.rcParams['legend.framealpha']),
+    ('legend_fancybox', 'Fancy Box', bool, False, plt.rcParams['legend.fancybox']),
+    ('legend_shadow', 'Shadow', bool, False, plt.rcParams['legend.shadow']),
+    ('legend_ncol', 'Number of Columns', int, False, 1),
+    ('legend_title', 'Title', str, False, ''),
+    ('legend_title_fontsize', 'Title Font Size',  ('xx-small', 'x-small', 'small', 'medium', 'large', 'x-large', 'xx-large'), False, plt.rcParams['legend.title_fontsize']),
+    ('legend_markerscale', 'Marker Scale', float, False, plt.rcParams['legend.markerscale']),
+    ('legend_numpoints', 'Number of Points', int, False, plt.rcParams['legend.numpoints']),
+    ('legend_labelspacing', 'Label Spacing', float, False, plt.rcParams['legend.labelspacing']),
+    ('legend_handlelength', 'Handle Length', float, False, plt.rcParams['legend.handlelength']),
+    ('legend_handletextpad', 'Handle-Text Pad', float, False, plt.rcParams['legend.handletextpad']),
+    ('legend_columnspacing', 'Column Spacing', float, False, plt.rcParams['legend.columnspacing']),
+    ('legend_labelcolor', 'Label Color', 'color', False, plt.rcParams['legend.labelcolor']),
+    ('legend_borderpad', 'Border Pad', float, False, plt.rcParams['legend.borderpad']),
+    ('legend_borderaxespad', 'Border-Axes Pad', float, False, plt.rcParams['legend.borderaxespad']),
+    ('legend_edgecolor', 'Edge Color', 'color', False, plt.rcParams['legend.edgecolor']),
+    ('legend_facecolor', 'Face Color', 'color', False, plt.rcParams['legend.facecolor']),
+    ('legend_handleheight', 'Handle Height', float, False, plt.rcParams['legend.handleheight']),
+    ('legend_scatterpoints', 'Scatter Points', int, False, plt.rcParams['legend.scatterpoints']),
+]
+
+# Store default values for resetting
+DEFAULTS = {name: default for name, _, _, _, default in PARAMETERS}
+
+class LegendModule(PlotModule):
+    """Adds a legend to plots with extensive customization"""
+    name = "Legend Module"
+    description = "Adds a highly customizable legend to plots"
+    PARAMETERS = PARAMETERS
+
+    def __init__(self, params=None):
+        super().__init__(params)
+        # Use the passed-in params, falling back to defaults
+        self.legend_params = {name.replace('legend_', ''): self.params.get(name, DEFAULTS[name]) for name in DEFAULTS}
+        # Special handling for title font size
+        if self.legend_params.get('title_fontsize') is None:
+            self.legend_params.pop('title_fontsize')
+
+    def plot(self, ax):
+        """Add legend to the plot using configured parameters"""
+        ax.legend(**self.legend_params)
+
+    def disable(self, ax):
+        """Remove the legend when the module is disabled"""
+        if ax.get_legend() is not None:
+            ax.get_legend().remove()

--- a/plot_modules/scale_module.py
+++ b/plot_modules/scale_module.py
@@ -1,0 +1,65 @@
+### WIP
+
+from gui.plot_module_widget import PlotModule
+from matplotlib.scale import get_scale_names
+from logger import get_logger
+
+logger = get_logger(__name__)
+
+# These are the strings accepted by ax.set_xscale() and ax.set_yscale()
+AVAILABLE_SCALE_TYPES = get_scale_names() #('linear', 'log', 'symlog', 'logit')
+
+# Define the parameters that the user can configure for axis scaling
+PARAMETERS = [
+    # (name, label, type, required, default_value)
+    ('x_scale_type', 'X-Axis Scale', AVAILABLE_SCALE_TYPES, False, 'linear'),
+    ('y_scale_type', 'Y-Axis Scale', AVAILABLE_SCALE_TYPES, False, 'linear'),
+]
+
+
+class ScaleModule(PlotModule):
+    """
+    Modifies the scale type of the X and Y axes (e.g., linear, logarithmic, symlog, logit).
+    """
+    name = "Axis Scale"
+    description = "Changes the scale type of the X and Y axes (e.g., linear, logarithmic)."
+    PARAMETERS = PARAMETERS
+
+    def __init__(self, params=None):
+        super().__init__(params)
+        self.x_scale_type = self.params.get('x_scale_type', 'linear')
+        self.y_scale_type = self.params.get('y_scale_type', 'linear')
+
+
+    def plot(self, ax):
+        """
+        Applies the selected scale types to the X and Y axes.
+        This also implicitly sets the appropriate tick locator and formatter.
+        For example, 'log' scale uses a LogLocator, while 'linear' uses an AutoLocator.
+        """
+        # Apply X-axis scale
+        try:
+            if ax.get_xscale() != self.x_scale_type:
+                ax.set_xscale(self.x_scale_type)
+                logger.debug(f"Set X-axis scale to: '{self.x_scale_type}'")
+        except ValueError as e:
+            logger.error(f"Error setting X-axis scale to '{self.x_scale_type}': {e}. "
+                         "Ensure data is positive for 'log' scales, or consider 'symlog' for data crossing zero.")
+        except Exception as e:
+            logger.error(f"Unexpected error setting X-axis scale to '{self.x_scale_type}': {e}")
+
+        # Apply Y-axis scale
+        try:
+            if ax.get_yscale() != self.y_scale_type:
+                ax.set_yscale(self.y_scale_type)
+                logger.debug(f"Set Y-axis scale to: '{self.y_scale_type}'")
+        except ValueError as e:
+            logger.error(f"Error setting Y-axis scale to '{self.y_scale_type}': {e}. "
+                         "Ensure data is positive for 'log' scales, or consider 'symlog' for data crossing zero.")
+        except Exception as e:
+            logger.error(f"Unexpected error setting Y-axis scale to '{self.y_scale_type}': {e}")
+
+    def disable(self, ax):
+        """
+        It should automatically be default unless specified otherwise
+        """

--- a/plot_modules/style_module.py
+++ b/plot_modules/style_module.py
@@ -1,0 +1,62 @@
+from gui.plot_module_widget import PlotModule
+import matplotlib.pyplot as plt
+from logger import get_logger
+
+logger = get_logger(__name__)
+available_styles = plt.style.available
+
+PARAMETERS = [
+    # (name, label, type, required, default_value)
+    ('style_name', 'Plot Style', tuple(available_styles), True, 'default'),
+]
+
+
+# --- 3. Create the StyleModule class ---
+class StyleModule(PlotModule):
+    """
+    Applies a global Matplotlib plot style.
+
+    Note: This changes the global style for all plots. It is highly
+    recommended to click 'Reload' on the Plot Modules widget after
+    applying a new style to update the default values in other modules.
+    """
+    name = "Plot Style"
+    description = "Applies a Matplotlib plot style (e.g., 'ggplot', 'seaborn'). Affects all plots. It is highly recommended to click 'Reload' on Plot Modules after changing the style."
+    PARAMETERS = PARAMETERS
+
+    def __init__(self, params=None):
+        super().__init__(params)
+        # Store the selected style name. Fallback to 'default' if not provided.
+        self.style_name = self.params.get('style_name', 'default')
+
+        # To ensure a clean reversion, we capture a copy of the 'default' style's
+        # rcParams when the module is instantiated.
+        with plt.style.context('default'): # THis will fuck with rcparam module for sure
+            self._default_rc_params = plt.rcParams.copy()
+
+    def plot(self, ax):
+        """
+        Apply the selected style globally.
+        This is a global change, so it doesn't just affect the passed 'ax'.
+        The main application will handle redrawing the canvas, which will now use the new style.
+        """
+        try:
+            # Applying the style will change the current plt.rcParams for the entire application.
+            plt.style.use(self.style_name)
+            logger.info(f"Applied global plot style: '{self.style_name}'")
+            # After applying, it's a good idea to force a reload of other modules' defaults.
+            # The user should be encouraged to use the "Reload" button in the PlotModuleWidget.
+        except Exception as e:
+            logger.error(f"Failed to apply style '{self.style_name}': {e}")
+
+    def disable(self, ax):
+        """
+        Revert the global style to Matplotlib's default configuration.
+        """
+        try:
+            # Revert to the captured default parameters.
+            # Using rc.update is the correct way to apply a dictionary of settings.
+            plt.rcParams.update(self._default_rc_params)
+            logger.info("Reverted plot style to Matplotlib default.")
+        except Exception as e:
+            logger.error(f"Failed to revert style to default: {e}")

--- a/plot_modules/style_module.py
+++ b/plot_modules/style_module.py
@@ -11,7 +11,6 @@ PARAMETERS = [
 ]
 
 
-# --- 3. Create the StyleModule class ---
 class StyleModule(PlotModule):
     """
     Applies a global Matplotlib plot style.
@@ -19,9 +18,11 @@ class StyleModule(PlotModule):
     Note: This changes the global style for all plots. It is highly
     recommended to click 'Reload' on the Plot Modules widget after
     applying a new style to update the default values in other modules.
+
+    This has an issue where the figure must be fully reloaded to take effect.
     """
     name = "Plot Style"
-    description = "Applies a Matplotlib plot style (e.g., 'ggplot', 'seaborn'). Affects all plots. It is highly recommended to click 'Reload' on Plot Modules after changing the style."
+    description = "Applies a Matplotlib plot style (e.g., 'ggplot', 'seaborn'). Affects all plots."
     PARAMETERS = PARAMETERS
 
     def __init__(self, params=None):
@@ -31,32 +32,28 @@ class StyleModule(PlotModule):
 
         # To ensure a clean reversion, we capture a copy of the 'default' style's
         # rcParams when the module is instantiated.
-        with plt.style.context('default'): # THis will fuck with rcparam module for sure
-            self._default_rc_params = plt.rcParams.copy()
+        self._default_rc_params = plt.rcParams.copy() # Honestly, consider removing this widget entirely
+        #with plt.style.context('default'): # THis will fuck with rcparam module for sure
+        #    self._default_rc_params = plt.rcParams.copy()
 
-    def plot(self, ax):
-        """
-        Apply the selected style globally.
-        This is a global change, so it doesn't just affect the passed 'ax'.
-        The main application will handle redrawing the canvas, which will now use the new style.
-        """
+    def initialize(self):
         try:
             # Applying the style will change the current plt.rcParams for the entire application.
             plt.style.use(self.style_name)
             logger.info(f"Applied global plot style: '{self.style_name}'")
-            # After applying, it's a good idea to force a reload of other modules' defaults.
-            # The user should be encouraged to use the "Reload" button in the PlotModuleWidget.
         except Exception as e:
             logger.error(f"Failed to apply style '{self.style_name}': {e}")
 
+        return True # Force a hard plot reset
+
+
     def disable(self, ax):
         """
-        Revert the global style to Matplotlib's default configuration.
+        Revert global style to what was previously in place
         """
         try:
-            # Revert to the captured default parameters.
-            # Using rc.update is the correct way to apply a dictionary of settings.
             plt.rcParams.update(self._default_rc_params)
             logger.info("Reverted plot style to Matplotlib default.")
         except Exception as e:
             logger.error(f"Failed to revert style to default: {e}")
+

--- a/plot_modules/style_module.py
+++ b/plot_modules/style_module.py
@@ -25,6 +25,8 @@ class StyleModule(PlotModule):
     description = "Applies a Matplotlib plot style (e.g., 'ggplot', 'seaborn'). Affects all plots."
     PARAMETERS = PARAMETERS
 
+    reset_plot = True # Forces plot reset whenever modified!
+
     def __init__(self, params=None):
         super().__init__(params)
         # Store the selected style name. Fallback to 'default' if not provided.
@@ -56,4 +58,6 @@ class StyleModule(PlotModule):
             logger.info("Reverted plot style to Matplotlib default.")
         except Exception as e:
             logger.error(f"Failed to revert style to default: {e}")
+
+        return True # Forces plot reset
 

--- a/plot_modules/ticks_modules.py
+++ b/plot_modules/ticks_modules.py
@@ -1,0 +1,324 @@
+# C:/Users/zberks/OneDrive - McGill University/G2/CorbinoAnalysis/plot_modules/ticks_modules.py
+from PyQt6.QtWidgets import QMessageBox
+
+from gui.plot_module_widget import PlotModule
+import matplotlib.pyplot as plt
+from logger import get_logger
+
+logger = get_logger(__name__)
+
+# --- 1. Centralized, Generic Parameter Definitions ---
+# This dictionary defines the core properties of each parameter, without specifying axis or type.
+# Format: generic_name: (UI Label Base, Type, Required)
+SHARED_TICK_PARAM_DEFS = {
+    'tick_values': ('Tick Values (csv)', str, False),
+    'tick_labels': ('Tick Labels (csv)', str, False),
+
+    'direction': ('Direction', ('in', 'out', 'inout'), False),
+    'labelsize': ('Label Size', ('xx-small', 'x-small', 'small', 'medium', 'large', 'x-large', 'xx-large'), False),
+    'labelcolor': ('Label Color', 'color', False),
+    'color': ('Tick Color', 'color', False),
+
+    'top': ('Show on Top', bool, False),
+    'bottom': ('Show on Bottom', bool, False),
+    'labeltop': ('Show Labels on Top', bool, False),
+    'labelbottom': ('Show Labels on Bottom', bool, False),
+    'left': ('Show on Left', bool, False),
+    'right': ('Show on Right', bool, False),
+    'labelleft': ('Show Labels on Left', bool, False),
+    'labelright': ('Show Labels on Right', bool, False),
+
+    'size': ('Size', float, False),
+    'width': ('Width', float, False),
+    'pad': ('Padding', float, False),
+}
+
+
+def _get_rc_param_default(axis, which, generic_key):
+    """
+    Helper to get the default rcParam value based on axis, which, and generic_key.
+    Handles the inconsistencies in rcParam naming by checking specific keys first.
+    """
+    rc_prefix = f"{axis}tick"
+    specific_key = f"{rc_prefix}.{which}.{generic_key}"
+    general_key = f"{rc_prefix}.{generic_key}"
+
+    # The global parameters overrides the local parameters so let's query that default instead
+    # provided that the value is a boolean
+    if general_key in plt.rcParams and plt.rcParams[general_key] in ['True', 'False', 'true', 'false', True, False, 't', 'f', 0, 1]:
+        return plt.rcParams[general_key]
+
+
+    # Try the most specific key first (e.g., 'xtick.major.size')
+    if specific_key in plt.rcParams:
+        #print(specific_key, plt.rcParams[specific_key])
+        return plt.rcParams[specific_key]
+
+    # Fallback to the general key (e.g., 'xtick.direction', 'xtick.top')
+    if general_key in plt.rcParams:
+        return plt.rcParams[general_key]
+
+    logger.warning(f"rcParam key could not be resolved for {axis}_{which}_{generic_key}. Using None.")
+    return None
+
+
+def build_params_list(axis, which, *generic_keys):
+    """
+    Helper function to build a PARAMETERS list for a specific axis and tick type.
+    It constructs the full parameter name and retrieves the default value from plt.rcParams.
+    """
+    result = []
+    for generic_key in generic_keys:
+        label_base, typ, required = SHARED_TICK_PARAM_DEFS[generic_key]
+
+        full_param_name = f"{axis}_{which}_{generic_key}"
+        ui_label = f"{axis.upper()} {which.capitalize()} {label_base}"
+
+        # Special handling for manual tick values/labels
+        if generic_key in ['tick_values', 'tick_labels']:
+            full_param_name = f"{axis}_{which}_{generic_key}"
+            ui_label = f"{axis.upper()} {which.capitalize()} {label_base}"
+            default_value = ''
+        else:
+            default_value = _get_rc_param_default(axis, which, generic_key)
+        result.append((full_param_name, ui_label, typ, required, default_value))
+    return result
+
+
+# --- 2. The Skeleton Base Class ---
+class __BaseSingleAxisTickModule(PlotModule):
+    """
+    A base class that handles the logic for a single axis and tick type.
+    Subclasses must define `axis` ('x' or 'y') and `which` ('major' or 'minor').
+    """
+    axis = None
+    which = None
+
+    def __init__(self, params=None):
+        super().__init__(params)
+        if not self.axis or not self.which:
+            raise NotImplementedError("Subclasses of BaseSingleAxisTickModule must define 'axis' and 'which'.")
+
+        # Prepare parameters for matplotlib functions
+        self.tick_values = self._parse_csv_to_float(self.params.get(f'{self.axis}_{self.which}_tick_values'))
+        self.tick_labels = self._parse_csv_to_str(self.params.get(f'{self.axis}_{self.which}_tick_labels'))
+
+        self.tick_params_kwargs = {}
+        for p_name, _, _, _, p_default in self.PARAMETERS:
+            # Skip manual tick settings, which are handled separately
+            if 'tick_values' in p_name or 'tick_labels' in p_name:
+                continue
+            #if 'color' in p_name and p_default in ['None', 'auto', 'inherit']:
+            #    p_default = None
+            # Lets try to not include a default, that way it doesn't automatically specify if the field is clear
+            #value = self.params.get(p_name, p_default)
+            value = self.params.get(p_name, None)
+            if 'color' in p_name and value in ['None', 'auto', 'inherit']:
+                value = None
+            if value:
+            # Extract the generic key (e.g., 'size' from 'x_major_size')
+                generic_key = p_name.replace(f"{self.axis}_{self.which}_", "")
+                self.tick_params_kwargs[generic_key] = value
+
+    def plot(self, ax):
+        """Applies the configured tick settings to the specified axis."""
+        # Set manual tick values if provided
+        set_ticks_func = getattr(ax, f'set_{self.axis}ticks')
+        if self.tick_values is not None:
+            set_ticks_func(self.tick_values, minor=(self.which == 'minor'))
+
+        # Set manual tick labels if provided
+        set_ticklabels_func = getattr(ax, f'set_{self.axis}ticklabels')
+        if self.tick_labels is not None:
+            set_ticklabels_func(self.tick_labels, minor=(self.which == 'minor'))
+
+        # Apply all other appearance settings
+        if self.tick_params_kwargs:
+            for k,v in self.tick_params_kwargs.items():
+                try:
+                    ax.tick_params(axis=self.axis, which=self.which, **{k:v})
+                except Exception as e:
+                    logger.error(f"Could not set tick parameters '{k}' to value '{v}' for axis '{self.axis}': {e} ")
+            #ax.tick_params(axis=self.axis, which=self.which, **self.tick_params_kwargs)
+
+    def disable(self, ax):
+        """Resets the tick settings for this module to their defaults."""
+        # Reset locators to default
+        axis_obj = getattr(ax, f'{self.axis}axis')
+        if self.which == 'major':
+            axis_obj.set_major_locator(plt.AutoLocator())
+            ax.set_xticklabels([]) if self.axis == 'x' else ax.set_yticklabels([])
+            for tick in axis_obj.get_major_ticks():
+                tick.tick2line.set_visible(False) # Removes the extra top tick that doesnt go away
+        else:  # minor
+            axis_obj.set_minor_locator(plt.NullLocator())
+
+        # Re-apply the default rcParams for this module's settings
+        #default_kwargs = {p[0].replace(f"{self.axis}_{self.which}_", ""): p[4]
+        #                  for p in self.PARAMETERS if 'tick_values' not in p[0] and 'tick_labels' not in p[0]}
+        ax.tick_params(axis=self.axis, which=self.which, reset=True)
+        # Reset top and left bug that occurs when dealing with majors
+        ax.tick_params(axis='both', which='both', top=False, right=False)
+
+    def _parse_csv_to_float(self, csv_string):
+        if not csv_string: return None
+        try:
+            return [float(v.strip()) for v in csv_string.split(',') if v.strip()]
+        except (ValueError, TypeError):
+            logger.warning(f"Could not parse float CSV: '{csv_string}'")
+            return None
+
+    def _parse_csv_to_str(self, csv_string):
+        if not csv_string: return None
+        return [v.strip() for v in csv_string.split(',') if v.strip() is not None]
+
+
+
+class __BaseMultiAxisTickModule(PlotModule):
+    axis = ['x', 'y']
+    which = ['major', 'minor']
+
+    def __init__(self, params=None):
+        super().__init__(params)
+
+        self.modules = {
+            'x':{'major': MajorXTickModule(params), 'minor': MinorXTickModule(params)},
+            'y':{'major': MajorYTickModule(params), 'minor': MinorYTickModule(params)}
+        }
+
+    def plot(self, ax):
+        for axis in self.axis:
+            for which in self.which:
+                self.modules[axis][which].plot(ax)
+
+    def disable(self, ax):
+        for axis in self.axis:
+            for which in self.which:
+                self.modules[axis][which].disable(ax)
+
+tick_keys = {
+    'x':{
+        'major':[
+           'tick_values', 'tick_labels', 'direction', 'labelsize', 'labelcolor', 'color',
+           'top', 'bottom', 'labeltop', 'labelbottom', 'size', 'width', 'pad'
+        ],
+        'minor': [
+            'tick_values', 'tick_labels', 'direction', 'color', 'top', 'bottom', 'size', 'width', 'pad'
+        ]
+    },
+    'y':{
+        'major':[
+           'tick_values', 'tick_labels', 'direction', 'labelsize', 'labelcolor', 'color',
+           'left', 'right', 'labelleft', 'labelright', 'size', 'width', 'pad'
+        ],
+        'minor': [
+            'tick_values', 'tick_labels', 'direction', 'color', 'left', 'right', 'size', 'width', 'pad'
+        ]
+    },
+}
+
+class MajorXTickModule(__BaseSingleAxisTickModule):
+    name = "X Major Ticks"
+    description = "Configures major ticks and labels for the X-axis."
+    axis = 'x'
+    which = 'major'
+    PARAMETERS = build_params_list(axis, which, *tick_keys['x']['major'])
+    DEFAULTS = {p[0]: p[4] for p in PARAMETERS}
+
+
+class MinorXTickModule(__BaseSingleAxisTickModule):
+    name = "X Minor Ticks"
+    description = "Configures minor ticks for the X-axis."
+    axis = 'x'
+    which = 'minor'
+    PARAMETERS = build_params_list(axis, which, *tick_keys['x']['minor'])
+    DEFAULTS = {p[0]: p[4] for p in PARAMETERS}
+
+    def plot(self, ax):
+        ax.minorticks_on()
+        super().plot(ax)
+
+    def disable(self, ax):
+        ax.minorticks_off()
+        super().disable(ax)
+
+
+class MajorYTickModule(__BaseSingleAxisTickModule):
+    name = "Y Major Ticks"
+    description = "Configures major ticks and labels for the Y-axis."
+    axis = 'y'
+    which = 'major'
+    PARAMETERS = build_params_list(axis, which, *tick_keys['y']['major'])
+    DEFAULTS = {p[0]: p[4] for p in PARAMETERS}
+
+
+class MinorYTickModule(__BaseSingleAxisTickModule):
+    name = "Y Minor Ticks"
+    description = "Configures minor ticks for the Y-axis."
+    axis = 'y'
+    which = 'minor'
+    PARAMETERS = build_params_list(axis, which,*tick_keys['y']['minor'])
+    DEFAULTS = {p[0]: p[4] for p in PARAMETERS}
+
+    def plot(self, ax):
+        ax.minorticks_on() # Will turn on xaxis minor ticks as well
+        super().plot(ax)
+
+    def disable(self, ax):
+        ax.minorticks_off()
+        super().disable(ax)
+
+
+class MajorMinorXTickModule(__BaseMultiAxisTickModule):
+    name = "X Major/Minor Ticks"
+    description = "Configures major and minor ticks and labels for the X-axis."
+    axis = ['x']
+    which = ['major', 'minor']
+    PARAMETERS = [
+        *build_params_list('x', 'major', *tick_keys['x']['major']),
+        *build_params_list('x', 'minor',*tick_keys['x']['major']), # Provided we give values for majors, we can do the same extended values with minor
+    ]
+    def plot(self, ax):
+        ax.minorticks_on() # Will turn on xaxis minor ticks as well
+        super().plot(ax)
+
+    def disable(self, ax):
+        ax.minorticks_off()
+        super().disable(ax)
+
+
+class MajorMinorYTickModule(__BaseMultiAxisTickModule):
+    name = "Y Major/Minor Ticks"
+    description = "Configures major and minor ticks and labels for the Y-axis."
+    axis = ['y']
+    which = ['major', 'minor']
+    PARAMETERS = [
+        *build_params_list('y', 'major', *tick_keys['y']['major']),
+        *build_params_list('y', 'minor', *tick_keys['y']['major']),
+    ]
+    def plot(self, ax):
+        ax.minorticks_on() # Will turn on xaxis minor ticks as well
+        super().plot(ax)
+
+    def disable(self, ax):
+        ax.minorticks_off()
+        super().disable(ax)
+
+
+"""
+I am commenting this out until i have time to fix it
+
+Basically, the problem is when trying to set ticks, it substitutes {which} in getattr which causes a problem.
+
+The solution is to rewrite the __Base which is currently working after HOURS of debugging
+
+class MajorBothTickModule(__BaseSingleAxisTickModule):
+    name = "X/Y Major/Minor Ticks"
+    description = "Configures major and minor ticks and labels for both axes."
+    which='both'
+    axis='both'
+    PARAMETERS = sorted(set([
+        *[(arg[0].replace('x', '').replace('major', '').strip(), arg[1].replace('X', '').replace('Major', '').strip(), *arg[2:]) for arg in build_params_list('x', 'major', *tick_keys['x']['major'])],
+        *[(arg[0].replace('y', '').replace('major', '').strip(), arg[1].replace('Y', '').replace('Major', '').strip(), *arg[2:]) for arg in build_params_list('y', 'major', *tick_keys['y']['major'])],
+    ]),key=lambda x:x[1])
+"""

--- a/plot_modules/ticks_modules.py
+++ b/plot_modules/ticks_modules.py
@@ -1,15 +1,9 @@
-# C:/Users/zberks/OneDrive - McGill University/G2/CorbinoAnalysis/plot_modules/ticks_modules.py
-from PyQt6.QtWidgets import QMessageBox
-
 from gui.plot_module_widget import PlotModule
 import matplotlib.pyplot as plt
 from logger import get_logger
 
 logger = get_logger(__name__)
 
-# --- 1. Centralized, Generic Parameter Definitions ---
-# This dictionary defines the core properties of each parameter, without specifying axis or type.
-# Format: generic_name: (UI Label Base, Type, Required)
 SHARED_TICK_PARAM_DEFS = {
     'tick_values': ('Tick Values (csv)', str, False),
     'tick_labels': ('Tick Labels (csv)', str, False),
@@ -85,7 +79,7 @@ def build_params_list(axis, which, *generic_keys):
     return result
 
 
-# --- 2. The Skeleton Base Class ---
+# The Skeleton Base Classes
 class __BaseSingleAxisTickModule(PlotModule):
     """
     A base class that handles the logic for a single axis and tick type.
@@ -216,6 +210,8 @@ tick_keys = {
         ]
     },
 }
+
+# Actual tick modules
 
 class MajorXTickModule(__BaseSingleAxisTickModule):
     name = "X Major Ticks"

--- a/plot_modules/ticks_modules.py
+++ b/plot_modules/ticks_modules.py
@@ -152,7 +152,9 @@ class __BaseSingleAxisTickModule(PlotModule):
         #                  for p in self.PARAMETERS if 'tick_values' not in p[0] and 'tick_labels' not in p[0]}
         ax.tick_params(axis=self.axis, which=self.which, reset=True)
         # Reset top and left bug that occurs when dealing with majors
-        ax.tick_params(axis='both', which='both', top=False, right=False)
+        # ax.tick_params(axis='both', which='both', top=False, right=False)
+
+        return True # To reset plot
 
     def _parse_csv_to_float(self, csv_string):
         if not csv_string: return None
@@ -189,6 +191,7 @@ class __BaseMultiAxisTickModule(PlotModule):
         for axis in self.axis:
             for which in self.which:
                 self.modules[axis][which].disable(ax)
+        return True
 
 tick_keys = {
     'x':{
@@ -236,7 +239,7 @@ class MinorXTickModule(__BaseSingleAxisTickModule):
 
     def disable(self, ax):
         ax.minorticks_off()
-        super().disable(ax)
+        return super().disable(ax)
 
 
 class MajorYTickModule(__BaseSingleAxisTickModule):
@@ -262,7 +265,7 @@ class MinorYTickModule(__BaseSingleAxisTickModule):
 
     def disable(self, ax):
         ax.minorticks_off()
-        super().disable(ax)
+        return super().disable(ax)
 
 
 class MajorMinorXTickModule(__BaseMultiAxisTickModule):
@@ -280,7 +283,7 @@ class MajorMinorXTickModule(__BaseMultiAxisTickModule):
 
     def disable(self, ax):
         ax.minorticks_off()
-        super().disable(ax)
+        return super().disable(ax)
 
 
 class MajorMinorYTickModule(__BaseMultiAxisTickModule):
@@ -298,7 +301,7 @@ class MajorMinorYTickModule(__BaseMultiAxisTickModule):
 
     def disable(self, ax):
         ax.minorticks_off()
-        super().disable(ax)
+        return super().disable(ax)
 
 
 """


### PR DESCRIPTION
Added user-customizeable plot modules. These plot modules can control ticks/scaling/styles/etc. There are three functions which will be run at different times in the plotting sequence:

- initialize(), an optional function which will be ran before the figure/axes are created. This would pertain to any modifications to global parameters ideally.
- plot(ax), this function will be run after plotting the data but before the canvas is drawn
- disable(ax), this function will be run should the user disable the module.

If a module requires that the figure/ax are recreated instead of just modified, the flag reset_plot = True will ensure that on deletion and creation, the figure/ax are recreated. Should it only be required at certain steps (i.e. on creation or deletion) then either initialize() or disable(ax) should return True to force a plot reset at these steps.

Example modules were created, but not all of them are good. For example, the colorbar currently has no use case despite it being operational.